### PR TITLE
throws tons of exceptions on values with a decimal separator

### DIFF
--- a/kendzi3d-plugin/src/main/java/kendzi/josm/kendzi3d/jogl/model/Road.java
+++ b/kendzi3d-plugin/src/main/java/kendzi/josm/kendzi3d/jogl/model/Road.java
@@ -364,7 +364,7 @@ public class Road extends AbstractWayModel {
         String widthStr = way.get("width");
         if (widthStr != null) {
             try {
-                return Long.parseLong(widthStr);
+                return Double.parseDouble(widthStr);
             } catch (Exception e) {
                 log.error(e, e);
             }


### PR DESCRIPTION
it's still not perfect as it should parse units and normalize the value to metre (i.e. "km" suffix times 1000 and so on)