### PR TITLE
fix Layer is not managed by us exception

### DIFF
--- a/kendzi3d-plugin/src/main/java/kendzi/josm/kendzi3d/ui/layer/CameraLayer.java
+++ b/kendzi3d-plugin/src/main/java/kendzi/josm/kendzi3d/ui/layer/CameraLayer.java
@@ -256,13 +256,9 @@ public class CameraLayer extends Layer implements LayerChangeListener {
      */
     @Override
     public void layerRemoving(LayerRemoveEvent evt) {
-        if (evt.getRemovedLayer() instanceof OsmDataLayer && !isOsmDataLayer()) {
-            MainApplication.getLayerManager().removeLayer(this);
-        } else if (evt.getRemovedLayer() == this) {
-            // XXX
-            // Always can be added layer!
-            // Main.getLayerManager().removeLayerChangeListener(this);
-        }
+        if (evt.getRemovedLayer() == this)
+            if (MainApplication.getLayerManager().containsLayer(this))
+            	MainApplication.getLayerManager().removeLayer(this);
     }
 
     private boolean isOsmDataLayer() {


### PR DESCRIPTION
without the proposed change JOSM throws something like this:

ReportedException [thread=Thread[AWT-EventQueue-1,6,main], exception=java.lang.IllegalArgumentException: CameraLayer [name=Kendzi3d camera layer, associatedFile=null] is not managed by us., methodWarningFrom=null]
        at org.openstreetmap.josm.tools.bugreport.BugReport.intercept(BugReport.java:173)
        at org.openstreetmap.josm.gui.layer.LayerManager.fireLayerRemoving(LayerManager.java:477)
        at org.openstreetmap.josm.gui.layer.LayerManager.realRemoveSingleLayer(LayerManager.java:277)
        at org.openstreetmap.josm.gui.layer.MainLayerManager.realRemoveSingleLayer(MainLayerManager.java:281)
        at org.openstreetmap.josm.gui.layer.LayerManager.realRemoveLayer(LayerManager.java:265)
        at org.openstreetmap.josm.gui.layer.LayerManager.lambda$removeLayer$1(LayerManager.java:247)
        at org.openstreetmap.josm.gui.util.GuiHelper.runInEDTAndWaitWithException(GuiHelper.java:234)
        at org.openstreetmap.josm.gui.layer.LayerManager.removeLayer(LayerManager.java:247)
        at org.openstreetmap.josm.gui.layer.LayerManager.realResetState(LayerManager.java:511)
        at org.openstreetmap.josm.gui.layer.MainLayerManager.realResetState(MainLayerManager.java:412)
        at org.openstreetmap.josm.gui.util.GuiHelper.runInEDTAndWaitWithException(GuiHelper.java:234)
        at org.openstreetmap.josm.gui.layer.LayerManager.resetState(LayerManager.java:502)
        at org.openstreetmap.josm.gui.MainApplication.shutdown(MainApplication.java:497)
        at org.openstreetmap.josm.Main.exitJosm(Main.java:319)
        at org.openstreetmap.josm.gui.MainApplication.exitJosm(MainApplication.java:639)
        at org.openstreetmap.josm.gui.MainFrame$ExitWindowAdapter.windowClosing(MainFrame.java:174)
        at java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:349)
        at java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:349)
        at java.awt.AWTEventMulticaster.windowClosing(AWTEventMulticaster.java:349)
        at java.awt.Window.processWindowEvent(Window.java:2054)
        at javax.swing.JFrame.processWindowEvent(JFrame.java:305)
        at java.awt.Window.processEvent(Window.java:2013)
        at java.awt.Component.dispatchEventImpl(Component.java:4889)
        at java.awt.Container.dispatchEventImpl(Container.java:2294)
        at java.awt.Window.dispatchEventImpl(Window.java:2746)
        at java.awt.Component.dispatchEvent(Component.java:4711)
        at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
        at java.awt.EventQueue.access$500(EventQueue.java:97)
        at java.awt.EventQueue$3.run(EventQueue.java:709)
        at java.awt.EventQueue$3.run(EventQueue.java:703)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:90)
        at java.awt.EventQueue$4.run(EventQueue.java:731)
        at java.awt.EventQueue$4.run(EventQueue.java:729)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
        at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
        at org.GNOME.Accessibility.AtkWrapper$5.dispatchEvent(AtkWrapper.java:700)
        at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
        at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
        at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
        at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
Caused by: java.lang.IllegalArgumentException: CameraLayer [name=Kendzi3d camera layer, associatedFile=null] is not managed by us.
        at org.openstreetmap.josm.gui.layer.LayerManager.checkContainsLayer(LayerManager.java:392)
        at org.openstreetmap.josm.gui.layer.LayerManager.realRemoveLayer(LayerManager.java:263)
        at org.openstreetmap.josm.gui.layer.LayerManager.lambda$removeLayer$1(LayerManager.java:247)
        at org.openstreetmap.josm.gui.util.GuiHelper.runInEDTAndWaitWithException(GuiHelper.java:234)
        at org.openstreetmap.josm.gui.layer.LayerManager.removeLayer(LayerManager.java:247)
        at kendzi.josm.kendzi3d.ui.layer.CameraLayer.layerRemoving(CameraLayer.java:260)
        at org.openstreetmap.josm.gui.layer.LayerManager.fireLayerRemoving(LayerManager.java:475)
        ... 43 more