### PR TITLE
update to Guice 4.2.0 and EJML 0.32

### DIFF
--- a/kendzi3d-collada-exporter/pom.xml
+++ b/kendzi3d-collada-exporter/pom.xml
@@ -39,9 +39,9 @@
 			<version>${log4j.version}</version>
 		</dependency>
 		<dependency>
-		    <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-		    <artifactId>ejml</artifactId>
-		    <version>0.20</version>
+		    <groupId>org.ejml</groupId>
+		    <artifactId>ejml-core</artifactId>
+		    <version>${ejml.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/kendzi3d-render/pom.xml
+++ b/kendzi3d-render/pom.xml
@@ -71,9 +71,9 @@
 		</dependency>
                    
         <dependency>
-		    <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-		    <artifactId>ejml</artifactId>
-		    <version>0.20</version>
+		    <groupId>org.ejml</groupId>
+		    <artifactId>ejml-core</artifactId>
+		    <version>${ejml.version}</version>
 		</dependency>
 		
         <dependency>

--- a/kendzi3d-tile-server/pom.xml
+++ b/kendzi3d-tile-server/pom.xml
@@ -153,9 +153,9 @@
 		</dependency>
                    
         <dependency>
-		    <groupId>com.googlecode.efficient-java-matrix-library</groupId>
-		    <artifactId>ejml</artifactId>
-		    <version>0.20</version>
+		    <groupId>org.ejml</groupId>
+		    <artifactId>ejml-core</artifactId>
+		    <version>${ejml.version}</version>
 		</dependency>
 		
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,13 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		<ejml.version>0.32</ejml.version>
 		<vecmath.version>1.3.1</vecmath.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<junit.version>4.12</junit.version>
 		<log4j.version>1.2.17</log4j.version>
 		<slf4j.version>1.7.25</slf4j.version>
-		<guice.version>4.1.0</guice.version>
+		<guice.version>4.2.0</guice.version>
 		<inject.version>1</inject.version>
 		
 		<jogl.version>2.3.2</jogl.version>


### PR DESCRIPTION
Guice 4.2.0 should help with Java 9+ support, see https://josm.openstreetmap.de/ticket/15128

EJML 0.32 is the same version as the one used by GeoTools 19 (current version of the JOSM GeoTools plugin)